### PR TITLE
Fix fst_snd_eq'

### DIFF
--- a/FriedmanStrongConv/Graph/Dart.lean
+++ b/FriedmanStrongConv/Graph/Dart.lean
@@ -145,12 +145,12 @@ lemma eq_iff {d₁ d₂ : G.Dart} : (d₁ = d₂) ↔ (d₁.fst = d₂.fst ∧ d
 /-- If two darts share an edge, then their starts points are the same iff their end points are the same. -/
 lemma fst_snd_eq {d₁ d₂ : G.Dart} (h : d₁.edge = d₂.edge) : d₁.fst = d₂.fst ↔ d₁.snd = d₂.snd := by
   dartcases d₁ and d₂ from h
-  all_goals constructor <;> intro lhs <;> trivial
+  all_goals constructor <;> intro lhs <;> cases lhs <;> rfl
 
 /-- If two darts share an edge, then first's start point is the seconds's end point iff the first's end point is the seconds's start point. -/
 lemma fst_snd_eq' {d₁ d₂ : G.Dart} (h : d₁.edge = d₂.edge) : d₁.fst = d₂.snd ↔ d₁.snd = d₂.fst := by
   dartcases d₁ and d₂ from h
-  all_goals constructor <;> intro lhs <;> sorry
+  all_goals constructor <;> intro lhs <;> cases lhs <;> rfl
 
 /-- The reversing operation on darts, which reverses its orientation. -/
 def reverse (d : G.Dart) : G.Dart :=

--- a/FriedmanStrongConv/Graph/Dart.lean
+++ b/FriedmanStrongConv/Graph/Dart.lean
@@ -145,12 +145,12 @@ lemma eq_iff {d₁ d₂ : G.Dart} : (d₁ = d₂) ↔ (d₁.fst = d₂.fst ∧ d
       apply (eq_iff_non_loop h).2
       exact ⟨hf, he⟩
 
-/-- If two darts share an edge, then their starts points are the same iff their end points are the same. -/
+/-- If two darts share an edge, then their start points are the same iff their end points are the same. -/
 lemma fst_snd_eq {d₁ d₂ : G.Dart} (h : d₁.edge = d₂.edge) : d₁.fst = d₂.fst ↔ d₁.snd = d₂.snd := by
   dartcases d₁ and d₂ from h
   all_goals constructor <;> (intro lhs; cases lhs; rfl)
 
-/-- If two darts share an edge, then first's start point is the seconds's end point iff the first's end point is the seconds's start point. -/
+/-- If two darts share an edge, then the first's start point is the second's end point iff the first's end point is the second's start point. -/
 lemma fst_snd_eq' {d₁ d₂ : G.Dart} (h : d₁.edge = d₂.edge) : d₁.fst = d₂.snd ↔ d₁.snd = d₂.fst := by
   dartcases d₁ and d₂ from h
   all_goals constructor <;> (intro lhs; cases lhs; rfl)


### PR DESCRIPTION
Fixes the proof of `fst_snd_eq'` now that it isn't `Iff.rfl`. Changed the proof of `fst_snd_eq` to use the same more direct tactic; I don't understand why I can't collapse `intro lhs; cases rhs` into `rintro rfl`.

Have also updated `dartcases` to not generate duplicate tactics because that was bothering me.